### PR TITLE
Support IPv6 only setups

### DIFF
--- a/src/knockd.c
+++ b/src/knockd.c
@@ -144,6 +144,7 @@ int target_strcmp(char *ip, char *target);
 pcap_t *cap = NULL;
 FILE *logfd = NULL;
 int lltype = -1;
+int hasIpV4 = 0;
 int hasIpV6 = 0;
 /* list of IP addresses for given interface
  */
@@ -276,6 +277,8 @@ int main(int argc, char **argv)
 				continue;
 
 			if((strcmp(ifa->ifa_name, o_int) == 0) && (ifa->ifa_addr->sa_family == AF_INET || (ifa->ifa_addr->sa_family == AF_INET6 && !o_skipIpV6))) {
+				if (ifa->ifa_addr->sa_family == AF_INET)
+					hasIpV4 = 1;
 				if (ifa->ifa_addr->sa_family == AF_INET6)
 					hasIpV6 = 1;
 				if((myip = calloc(1, sizeof(ip_literal_t))) == NULL) {
@@ -940,6 +943,11 @@ void generate_pcap_filter()
 	 */
 	for (ipv6 = 0 ; ipv6 <=1 ; ipv6++)
 	{
+		if (ipv6 == 0 && !hasIpV4)
+			continue;
+		if (ipv6 == 1 && !hasIpV6)
+			continue;
+
 		if (ipv6 && o_skipIpV6)
 			continue;
 		
@@ -1162,12 +1170,18 @@ void generate_pcap_filter()
 			door = (opendoor_t*)lp->data;
 			for (ipv6 = 0 ; ipv6 <= 1 ; ipv6++)
 			{
+				if (ipv6 == 0 && !hasIpV4)
+					continue;
+				if (ipv6 == 1 && !hasIpV6)
+					continue;
+
+				if (ipv6 && o_skipIpV6)
+					continue;
+
 				if (first)
 					first = 0;
 				else
 					bufsize = realloc_strcat(&buffer, " or ", bufsize);
-				if (ipv6 && o_skipIpV6)
-					continue;
 				if (ipv6)
 					bufsize = realloc_strcat(&buffer, door->pcap_filter_expv6, bufsize);
 				else


### PR DESCRIPTION
Just noticed this and made a PR in case you're interested.
Feel free to modify/close it or give me some feedback, if you don't like the implementation (did a minimal patch without any cleanup/refactoring).

## Debug output with this PR:

```
Local IP: 10.0.0.1
Adding pcap expression for door 'SSH': ((dst host 10.0.0.1) and (((tcp dst port 5000 or 6000 or 7000) and tcp[tcpflags] & tcp-syn != 0)))
```

```
Local IP: fd00:0:0:42::1
Adding pcap expression for door 'SSH': ((dst host fd00:0:0:42::1) and (((tcp dst port 5000 or 6000 or 7000) and ip6[13+40] & tcp-syn != 0)))
```

```
Local IP: 10.0.0.1
Local IP: fd00:0:0:42::1
Adding pcap expression for door 'SSH': ((dst host 10.0.0.1) and (((tcp dst port 5000 or 6000 or 7000) and tcp[tcpflags] & tcp-syn != 0)))
Adding pcap expression for door 'SSH': ((dst host fd00:0:0:42::1) and (((tcp dst port 5000 or 6000 or 7000) and ip6[13+40] & tcp-syn != 0)))
```

## From the commit message:

The code was producing an invalid pcap expression, if the interface has
no IPv4 address:

```
Local IP: fd00::1
Local IP: fe80::50ba:adff:fef0:d50
Adding pcap expression for door 'SSH': ) and (((tcp dst port 5000 or 6000 or 7000) and tcp[tcpflags] & tcp-syn != 0)))
Adding pcap expression for door 'SSH': ((dst host fe80::50ba:adff:fef0:d50 or dst host fd00::1) and (((tcp dst port 5000 or 6000 or 7000) and ip6[13+40] & tcp-syn != 0)))
pcap_compile: syntax error
```

The resulting filter:
```
") and (((tcp dst port 5000 or 6000 or 7000) and tcp[tcpflags] & tcp-syn != 0))) or ((dst host fe80::50ba:adff:fef0:d50 or dst host fd00::1) and (((tcp dst port 5000 or 6000 or 7000) and ip6[13+40] & tcp-syn != 0)))"
```

This commit will skip IPv4/IPv6 if necessary and therefore works, if the
interface has only IPv4 or IPV6 addresses.